### PR TITLE
Fix some typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Allowed attributes mapped to Http methods in module:
 
 ## :arrow_forward: Skipping files
 
-to skip file in routes directory, prepend the `.` or `_` charater to filename
+to skip file in routes directory, prepend the `.` or `_` character to filename
 
 examples:
 
@@ -124,7 +124,7 @@ routes
 ```
 > :warning: also any `*.test.js` and `*.test.ts` are skipped!
 
-this is useful if you want to have a lib file containts functions that don't have to be a route, so just create the file with `_` prepending character
+this is useful if you want to have a lib file which contains functions that don't have to be a route, so just create the file with `_` prepending character
 
 ## :page_facing_up: License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -87,7 +87,7 @@ Autoroutes directory scenario:
         └── world.js  => http://your-host/hello/world
 ```
 
-in this case, the plugin will recursivley scan any routes in directory and map it urls
+in this case, the plugin will recursively scan any routes in directory and map it urls
 
 > :warning: those two directory structure are **NOT** equivalent:
 >
@@ -111,7 +111,7 @@ in this case, the plugin will recursivley scan any routes in directory and map i
 to ignore routes there are few way:
 
 - prepend '.' character to your file/directory name
-- prepend '_' characher to your file/directory name
+- prepend '_' character to your file/directory name
 
 > :information_source: files `*.test.js` and `*.test.ts` are automatically ignored
 
@@ -208,7 +208,7 @@ export default (fastifyInstance) => ({
 
 ### Route definition
 
-Each route should be complaint to fastify route: [Method Specification](https://www.fastify.io/docs/latest/Routes/#full-declaration)
+Each route should be compliant to fastify route: [Method Specification](https://www.fastify.io/docs/latest/Routes/#full-declaration)
 
 the only exceptions is for `url` and `method` which are automatically mapped by project structure.
 


### PR DESCRIPTION
Was reading the docs and noticed some typo so I fixed them. Then I also did a quick check in the repo README file as well just to be thorough. The only slightly bigger change would be the following (repo README file line 127):

original: `lib file containts functions`
changed to: `lib file which contains functions`

just changing `containts` to `contains` seems abit off, hence I added  `which` before it. Hope that's okay :)