### PR TITLE
feat: Allow specifying multiple url params in the same "/" part

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,11 @@
-import fastifyPlugin from 'fastify-plugin'
 import { FastifyInstance, RouteOptions } from 'fastify'
-
-import {
-  JsonSchema,
-  JsonSchemaProperty,
-  ObjectJsonSchemaProperty,
-} from 'type-jsonschema'
+import fastifyPlugin from 'fastify-plugin'
+import fs from 'fs'
+import path from 'path'
 
 import process from 'process'
-import path from 'path'
-import fs from 'fs'
+
+import { JsonSchemaProperty, ObjectJsonSchemaProperty } from 'type-jsonschema'
 
 export const errorLabel = '[ERROR] fastify-autoload:'
 
@@ -99,7 +95,7 @@ function scan(
   fastify: FastifyInstance,
   baseDir: string,
   current: string,
-  log: boolean = false
+  log: boolean = false,
 ) {
   const combined = path.join(baseDir, current)
   const combinedStat = fs.statSync(combined)
@@ -139,30 +135,20 @@ function pathToUrl(filePath: string) {
 }
 
 function replaceParamsToken(token: string) {
-  const regex = /{.+}/g
-
-  let result
-  while ((result = regex.exec(token)) !== null) {
-    token =
-      token.substring(0, result.index) +
-      result[0].replace('{', ':').replace('}', '') +
-      token.substr(result.index + result[0].length)
-  }
-
-  return token
+  return token.replace(/{([^}]+)}/g, (_, match) => `:${match}`)
 }
 
 function autoload(
   fastify: FastifyInstance,
   fullPath: string,
   url: string,
-  log: boolean
+  log: boolean,
 ) {
   const module = loadModule(fullPath, log)
 
   if (typeof module !== 'function') {
     throw new Error(
-      `${errorLabel} module ${fullPath} must be valid js/ts module and should export route methods definitions`
+      `${errorLabel} module ${fullPath} must be valid js/ts module and should export route methods definitions`,
     )
   }
 
@@ -240,7 +226,7 @@ export default fastifyPlugin<FastifyAutoroutesOptions>(
 
     try {
       scan(fastify, dirPath, '', options.log)
-    } catch (error) {
+    } catch (error: any) {
       log && console.error(error.message)
 
       return next(error)
@@ -251,5 +237,5 @@ export default fastifyPlugin<FastifyAutoroutesOptions>(
   {
     fastify: '>=3.0.0',
     name: 'fastify-autoroutes',
-  }
+  },
 )

--- a/tests/routes.test.js
+++ b/tests/routes.test.js
@@ -77,7 +77,7 @@ tap.test('simple index', { saveFixture: false }, (t) => {
       t.is(err, null)
       t.is(res.payload, 'get')
       t.end()
-    }
+    },
   )
 })
 
@@ -103,7 +103,7 @@ tap.test('nested routes', { saveFixture: false }, (t) => {
       t.is(err, null)
       t.is(res.payload, 'get')
       t.end()
-    }
+    },
   )
 })
 
@@ -131,7 +131,7 @@ tap.test('nested routes with trailing slashes', { saveFixture: false }, (t) => {
       t.is(err, null)
       t.is(res.payload, 'get')
       t.end()
-    }
+    },
   )
 })
 
@@ -159,7 +159,7 @@ tap.test('nested routes with url parameter', { saveFixture: false }, (t) => {
       t.is(err, null)
       t.is(res.payload, userId)
       t.end()
-    }
+    },
   )
 })
 
@@ -205,12 +205,12 @@ tap.test(
               t.is(err, null)
               t.is(JSON.parse(res.payload).USERID, USERID)
               t.end()
-            }
+            },
           )
-        }
+        },
       )
     }
-  }
+  },
 )
 
 tap.test(
@@ -242,9 +242,46 @@ tap.test(
         t.is(err, null)
         t.is(res.payload, userId)
         t.end()
-      }
+      },
     )
-  }
+  },
+)
+
+tap.test(
+  'nested routes with url 2 parameters',
+  { saveFixture: false },
+  (t) => {
+    const server = fastify()
+
+    const dir = t.testdir({
+      users: {
+        '{userId}-{userName}': {
+          'foo': exampleGetRouteJSONParam,
+        },
+      },
+    })
+
+    server.register(autoroutes, {
+      dir: dir,
+    })
+
+    const userId = 'foo'
+    const userName = 'bar'
+
+    server.inject(
+      {
+        method: 'GET',
+        url: `/users/${userId}-${userName}/foo`,
+      },
+      (err, res) => {
+        const payload = JSON.parse(res.payload)
+        t.is(err, null)
+        t.is(payload.userId, userId)
+        // t.is(payload.userName, userName)
+        t.end()
+      },
+    )
+  },
 )
 
 tap.test('example es6 exports default module', { saveFixture: false }, (t) => {
@@ -267,7 +304,7 @@ tap.test('example es6 exports default module', { saveFixture: false }, (t) => {
       t.is(err, null)
       t.is(res.payload, 'get')
       t.end()
-    }
+    },
   )
 })
 
@@ -302,11 +339,11 @@ tap.test(
             t.is(res.statusCode, 404)
 
             t.end()
-          }
+          },
         )
-      }
+      },
     )
-  }
+  },
 )
 
 tap.test(
@@ -340,11 +377,11 @@ tap.test(
           (err, res) => {
             t.is(res.statusCode, 404)
             t.end()
-          }
+          },
         )
-      }
+      },
     )
-  }
+  },
 )
 
 tap.test(
@@ -379,9 +416,9 @@ tap.test(
           (err, res) => {
             t.is(res.statusCode, 404)
             t.end()
-          }
+          },
         )
-      }
+      },
     )
-  }
+  },
 )


### PR DESCRIPTION
As specified by [fastify docs](https://www.fastify.io/docs/latest/Routes/#url-building), it is allows to muse multiple params.

The while code was not supported it.