### PR TITLE
Windows path conflicts with glob paths

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -122,8 +122,12 @@ export default fastifyPlugin<FastifyAutoroutesOptions>(
       )
     }
 
-    const routes = await glob(`${dirPath}/**/[!.]*.{ts,js}`)
+    let routes = await glob(`${dirPath}/**/[!.]*.{ts,js}`)
     const routesModules: Record<string, StrictResource> = {}
+
+    // glob returns ../../, but windows returns ..\..\
+    routes = routes.map((route) => path.normalize(route).replace(/\\/g, '/'))
+    dirPath = path.normalize(dirPath).replace(/\\/g, '/')
 
     // console.log({ routes })
 


### PR DESCRIPTION
Hello,

I recently wanted to migrate my project to use your auto-route module, but when I finished all my routes were gone (I got 404s when I tried to GET them).

Then i logged out the finished route names in your module:

![Code_NL6C4LNWut](https://user-images.githubusercontent.com/56039679/154254576-d012b2e3-ae06-460d-a1bd-83b569a56a0e.png)

As you can see, the glob routes are ../../ but when I path.resolve("./routes/"), windows returns ..\\..\\..

I wrote this quick fix which works for my windows system in both cases.