### PR TITLE
feat: remove trailing `/` to allow query parameters

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -148,8 +148,13 @@ export default fastifyPlugin<FastifyAutoroutesOptions>(
       routesModules[routeName] = loadModule(routeName, route)(fastify)
     }
 
-    for (const [url, module] of Object.entries(routesModules)) {
+    for (let [url, module] of Object.entries(routesModules)) {
       for (const [method, options] of Object.entries(module)) {
+        // If resource url ends with trailing /, remove it
+        if (url.endsWith('/') && url !== '/') { 
+          url = url.slice(0, -1)
+        }
+
         fastify.route({
           method: method.toUpperCase(),
           url: url,


### PR DESCRIPTION
I am running into an issue when trying to use a structure like this:

```
routes/
├─ projects/
│  ├─ index.ts
```
This will get mapped to `www.example.com/projects/`

Which means trying to use query parameters with the url `www.example.com/projects?case=abc123` will return:
```
{
    "error": "Not Found",
    "message": "Route GET:/projects?case=abc123 not found",
    "statusCode": 404
}
```

From my understanding of searching the issue, people tend to lean toward the idea where non trailing slash urls ex. `/project` provide a resource. Where urls that do provide the trailing slash ex. `/project/` are more synonymous with directories.

I think this might cause issues for existing implementations, but I think making it more consistent or some way of expressing when a trailing slash is included is important. Specifically so that in the case above we can use query parameters.