### PR TITLE
Ignore underscore and dots

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,7 @@ export default fastifyPlugin<FastifyAutoroutesOptions>(
       )
     }
 
-    let routes = await glob(`${dirPath}/**/[!._]*.{ts,js}`)
+    let routes = await glob(`${dirPath}/**/[!._]*/[!._]*.{ts,js}`)
     const routesModules: Record<string, StrictResource> = {}
 
     // glob returns ../../, but windows returns ..\..\

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,7 @@ export default fastifyPlugin<FastifyAutoroutesOptions>(
       )
     }
 
-    let routes = await glob(`${dirPath}/**/[!.]*.{ts,js}`)
+    let routes = await glob(`${dirPath}/**/[!._]*.{ts,js}`)
     const routesModules: Record<string, StrictResource> = {}
 
     // glob returns ../../, but windows returns ..\..\


### PR DESCRIPTION
As per docs, currently it was only ignoring files with a dot at the start. Now it will also ignore underscores.

Also, the docs say that it will ignore files within a folder that has an underscore or a dot. This behavior kinda works, only 1 level deep.

![firefox_7tXcMc6Na4](https://user-images.githubusercontent.com/56039679/175296882-ed4c6194-5a16-4029-8eeb-5ac241b53c84.png)

See the screenshot, "_ignored" folder,  first child "index.ts" gets ignored, but once we go 2 levels deep, it doesn't get ignored. I'm not sure if it is possible to write a glob that recursively goes up and checks for underscores